### PR TITLE
Fix empty player name when compiling with GCC on Gentoo

### DIFF
--- a/src/common/common.c
+++ b/src/common/common.c
@@ -1860,7 +1860,9 @@ void Info_RemoveKey(char* s, char* key) {
         *o = 0;
 
         if (!strcmp(key, pkey)) {
-            strcpy(start, s); // remove this part
+	        size_t s_length = strlen(s);
+	        memmove(start, s, s_length);
+	        start[s_length] = '\0';
             return;
         }
 


### PR DESCRIPTION
strcpy in Info_RemoveKey was causing the info string to be corrupted, because of that player joined the server with empty name

![image](https://github.com/user-attachments/assets/a66ea62c-7367-4b16-aae7-c7dbb2a84a4e)
